### PR TITLE
Update plot_nds_compar.R

### DIFF
--- a/R/plot_nds_compar.R
+++ b/R/plot_nds_compar.R
@@ -1,19 +1,30 @@
-plot_nds_compar <- function(listg, graph2, doss = getwd(), var = "type") {
-    flistg <- unlist(listg, recursive = FALSE)  # flatten list
-    lidf <- unique(unlist(lapply(flistg, function(x) x$name)))
-    ldec.comp <- t(utils::combn(lidf, 2))  # all pairwise comparisons
-    A <- graph2[1]
-    B <- graph2[2]  # ; nb.comm.eds <-
-    ridx <- which(ldec.comp[, 1] == A & ldec.comp[, 2] == B, arr.ind = T)
-    g <- listg[[ridx]]  # a row = two graphs
-    out.compar <- paste0("compar_nds_", as.character(A), "_", as.character(B),
-        ".png")
-    tit <- paste0("nodes: compare decorations '", A, "' and '", B, "'")
-    grDevices::png(out.compar, width = 14, height = 7, units = "cm", res = 300)
-    graphics::par(mfrow = c(1, 2), mar = c(0, 0, 0, 0))  # set the plotting area into a 1*2 array
-    side_plot_nds(g, 1, doss, var)
-    side_plot_nds(g, 2, doss, var)  # call to plot
-    graphics::mtext(tit, side = 1, line = -1, outer = TRUE, cex = 0.6)
-    grDevices::dev.off()
-    return(paste0(getwd(), "/", out.compar))
+plot_nds_compar <- function(listg, graph2 = NULL, doss = getwd(), var = "type",
+                            common.nds.color = "red", different.nds.color = "orange",
+                            common.nds.size = 1, different.nds.size = 0.5,
+                            eds.color = "orange") {
+    # Gathering "different" and "common" parameters in vectors
+    # avoids if statements.
+    nds.color <- c(different.nds.color, common.nds.color)
+    nds.size  <- c(different.nds.size,  common.nds.size)
+    out.compar.list <- character(0)
+    for(i in 1:length(listg)) {
+        g <- listg[[i]]
+        g.names <- unlist(lapply(g, function(x) x$name))
+        if(is.null(graph2) || all(g.names %in% graph2)) {
+            out.compar <- paste0("compar_nds_", g.names[1], "_",
+                                 g.names[2], ".png")
+            tit <- paste0("nodes: compare decorations '", g.names[1],
+                          "' and '", g.names[2], "'")
+            grDevices::png(out.compar, width = 14, height = 7,
+                           units = "cm", res = 300)
+            # Set the plotting area into a 1*2 array
+            graphics::par(mfrow = c(1, 2), mar = c(0, 0, 0, 0))
+            side_plot_nds(g[[1]], doss, var, nds.color, nds.size, eds.color)
+            side_plot_nds(g[[2]], doss, var, nds.color, nds.size, eds.color)
+            graphics::mtext(tit, side = 1, line = -1, outer = TRUE, cex = 0.6)
+            grDevices::dev.off()
+            out.compar.list[length(out.compar.list) + 1] <- out.compar
+        }
+    }
+    return(paste0(getwd(), "/", out.compar.list))
 }


### PR DESCRIPTION
Several added functionalities:

1. The color of common and different vertices are now stated in this plot function instead of in list_nds_compar.
2. The color of the edges is now a parameter.
3. The selected graphs to compare (<graph2>) can be now any list (not necessarily a pair). 
From all pairs included in the list <listg>, they are plotted if both graphs are in <graph2>. 
For instance, graph2=c(1,2,3), plot the comparisons of (1,2), (1,3), and (2,3), provided that they are included in <listg>.
The default graph2=NULL, indicates that all pairs are plotted.
4. A second effect of this functionality is that the input <listg> doesn't need to be the complete list produced by list_nds_compar.
Any sublist could be given in <listg>.