### PR TITLE
Update plot_nds_compar.R

### DIFF
--- a/R/plot_nds_compar.R
+++ b/R/plot_nds_compar.R
@@ -1,31 +1,19 @@
 plot_nds_compar <- function(listg, graph2 = NULL, doss = getwd(), var = "type",
                             common.nds.color = "red", different.nds.color = "orange",
-                            common.nds.size = 1, different.nds.size = 0.5, lbl.size = 0.4,
-                            eds.color = "orange") {
+                            common.nds.size = 1, different.nds.size = 0.5,
+                            eds.color = "orange", eds.width = 1,
+                            lbl.size = 0.4,
+                            img.format = "png", res = 300) {
     # Gathering "different" and "common" parameters in vectors
     # avoids if statements.
     nds.color <- c(different.nds.color, common.nds.color)
     nds.size  <- c(different.nds.size,  common.nds.size)
-    out.compar.list <- character(0)
-    for(i in 1:length(listg)) {
-        # i <- 1
-        g <- listg[[i]]
-        g.names <- unlist(lapply(g, function(x) x$name))
-        if(is.null(graph2) || all(g.names %in% graph2)) {
-            out.compar <- paste0("compar_nds_", g.names[1], "_",
-                                 g.names[2], ".png")
-            tit <- paste0("nodes: compare decorations '", g.names[1],
-                          "' and '", g.names[2], "'")
-            grDevices::png(out.compar, width = 14, height = 7,
-                           units = "cm", res = 300)
-            # Set the plotting area into a 1*2 array
-            graphics::par(mfrow = c(1, 2), mar = c(0, 0, 0, 0))
-            side_plot_nds(g[[1]], doss, var, nds.color, nds.size, eds.color, lbl.size)
-            side_plot_nds(g[[2]], doss, var, nds.color, nds.size, eds.color, lbl.size)
-            graphics::mtext(tit, side = 1, line = -1, outer = TRUE, cex = 0.6)
-            grDevices::dev.off()
-            out.compar.list[length(out.compar.list) + 1] <- out.compar
-        }
-    }
-    return(paste0(getwd(), "/", out.compar.list))
+    eds.color <- rep(eds.color, 2)
+    eds.width <- rep(eds.width, 2)
+
+    return(plot_compar(listg, graph2, "nodes", doss, var,
+                       nds.color, nds.size,
+                       eds.color, eds.width,
+                       lbl.size,
+                       img.format, res))
 }


### PR DESCRIPTION
Functions "plot_nds_compar" and "plot_eds_compar"  are now just interfaces calling the function plot_compar with options focus = "nodes" and focus = "edges", respectively.
I actually propose to remove "plot_nds_compar" and "plot_eds_compar" and to use directly plot_compar, which is sufficiently versatile and simple.