### PR TITLE
Update plot_eds_compar.R

### DIFF
--- a/R/plot_eds_compar.R
+++ b/R/plot_eds_compar.R
@@ -1,20 +1,19 @@
-plot_eds_compar <- function(listg, graph2, doss = getwd(), var = "type", lbl.size = 0.4) {
-    flistg <- unlist(listg, recursive = FALSE)  # flatten list
-    lidf <- unique(unlist(lapply(flistg, function(x) x$name)))
-    ldec.comp <- t(utils::combn(lidf, 2))  # all pairwise comparisons
-    A <- graph2[1]
-    B <- graph2[2]  # ; nb.comm.eds <-
-    ridx <- which(ldec.comp[, 1] == A & ldec.comp[, 2] == B, arr.ind = T)
-    g <- listg[[ridx]]
-    out.compar <- paste0("compar_eds_", as.character(A), "_", as.character(B),
-        ".png")
-    tit <- paste0("edges: compare decorations '", A, "' and '", B, "' on '",
-        var, "'")
-    grDevices::png(out.compar, width = 14, height = 7, units = "cm", res = 300)
-    graphics::par(mfrow = c(1, 2), mar = c(0, 0, 0, 0))  # set the plotting area into a 1*2 array
-    side_plot_eds(g, 1, doss, var, lbl.size)
-    side_plot_eds(g, 2, doss, var, lbl.size)  # call to plot
-    graphics::mtext(tit, side = 1, line = -1, outer = TRUE, cex = 0.8)
-    grDevices::dev.off()
-    return(paste0(getwd(), "/", out.compar))
+plot_eds_compar <- function(listg, graph2 = NULL, doss = getwd(), var = "type",
+                            common.eds.color = "red", different.eds.color = "orange",
+                            common.eds.width = 2, different.eds.width = 1,
+                            nds.size = 0.5,
+                            lbl.size = 0.4,
+                            img.format = "png", res = 300) {
+    # Gathering "different" and "common" parameters in vectors
+    # avoids if statements.
+    eds.color <- c(different.eds.color, common.eds.color)
+    eds.width <- c(different.eds.width,  common.eds.width)
+    nds.color = eds.color
+    nds.size = rep(nds.size, 2)
+
+    return(plot_compar(listg, graph2, "edges", doss, var,
+                       nds.color, nds.size,
+                       eds.color, eds.width,
+                       lbl.size,
+                       img.format, res))
 }


### PR DESCRIPTION
Functions "plot_nds_compar" and "plot_eds_compar"  are now just interfaces calling the function plot_compar with options focus = "nodes" and focus = "edges", respectively.
I actually propose to remove "plot_nds_compar" and "plot_eds_compar" and to use directly plot_compar, which is sufficiently versatile and simple.