### PR TITLE
Patch 46

### DIFF
--- a/R/contemp_nds.R
+++ b/R/contemp_nds.R
@@ -1,16 +1,14 @@
-contemp_nds <- function(nds.df, eds.df, selected.nd, var = "type"){
+contemp_nds <- function(nds.df, eds.df, selected.nd){
   # selected.nd <- 3
   nds.g.cols <- !(names(nds.df) %in% c("site", "decor"))
   eds.g.cols <- !(names(eds.df) %in% c("site", "decor"))
   g <- igraph::graph_from_data_frame(eds.df[eds.g.cols],
                                      vertices = nds.df[nds.g.cols],
                                      directed=FALSE)
-  eds.overlap <- which(igraph::edge_attr(g, var) == '>')
+  eds.overlap <- which(igraph::E(g)$type == ">")
   g <- igraph::delete.edges(g, eds.overlap)
   g.member <- igraph::components(g)$membership
-  nds.overlap <- which(g.member != g.member[selected.nd])
+  contemp.cases <- g.member == g.member[selected.nd]
 
-  nds.df.contemp <- nds.df[-nds.overlap, ]
-  eds.df.contemp <- eds.df[-eds.overlap, ]
-  return(list(nds.df.contemp, eds.df.contemp))
+  return(list(nds.df[contemp.cases, ], eds.df[contemp.cases, ]))
 }

--- a/R/list_dec.R
+++ b/R/list_dec.R
@@ -1,6 +1,4 @@
-list_dec <- function(imgs, nodes, edges, var = "type") {
-    # 'var': field on which the comparison will be done create list of
-    # graphs
+list_dec <- function(imgs, nodes, edges) {
     lgrph <- list()
     for (r in 1:nrow(imgs)) {
         a.enr <- imgs[r, ]
@@ -11,9 +9,6 @@ list_dec <- function(imgs, nodes, edges, var = "type") {
         # create graph
         g <- igraph::graph_from_data_frame(g.edges, directed = FALSE,
                                            vertices = g.nodes)
-        # Vertex names saved as idf and replaced by types.
-        igraph::V(g)$idf <- igraph::V(g)$name
-        igraph::V(g)$name <- igraph::vertex_attr(g, var)
         # attributes
         g$name <- a.enr$idf
         g$site <- a.enr$site

--- a/R/plot_compar.R
+++ b/R/plot_compar.R
@@ -1,8 +1,8 @@
 plot_compar <- function(listg, graph2 = NULL, focus = "nodes",
-                        doss = getwd(), var = "type",
+                        doss = getwd(), nds.var = "type",
                         nds.color = c("orange", "red"), nds.size = c(0.5, 1),
                         eds.color = c("orange", "red"), eds.width = c(1, 2),
-                        lbl.size = 0.4,
+                        lbl.size = 0.5,
                         img.format = "png", res = 300) {
 # If a single value is set for an nds or eds parameter, it affects both types:
   if (length(nds.color) == 1) nds.color[2] <- nds.color[1]
@@ -19,7 +19,7 @@ plot_compar <- function(listg, graph2 = NULL, focus = "nodes",
     if (missing(nds.size)) nds.size[2] <- nds.size[1]
     img.prefix <- "compar_eds_"
     caption.heading <- "edges: "
-    caption.end <- paste0(" on '", var, "'")
+    caption.end <- paste0(" on '", nds.var, "'")
   } else {
     stop(paste0("focus must be \"nodes\" or \"edges\"."))
   }
@@ -37,9 +37,9 @@ plot_compar <- function(listg, graph2 = NULL, focus = "nodes",
       decorr::grDeviceOpen(out.compar, width = 14, height = 7, res = res)
       # Set the plotting area into a 1*2 array
       graphics::par(mfrow = c(1, 2), mar = c(0, 0, 0, 0))
-      side_plot(g[[1]], doss, var, focus,
+      side_plot(g[[1]], doss, nds.var, focus,
                 nds.color, nds.size, eds.color, eds.width, lbl.size)
-      side_plot(g[[2]], doss, var, focus,
+      side_plot(g[[2]], doss, nds.var, focus,
                 nds.color, nds.size, eds.color, eds.width, lbl.size)
       graphics::mtext(tit, side = 1, line = -1, outer = TRUE, cex = 0.6)
       grDevices::dev.off()

--- a/R/plot_dec_grph.R
+++ b/R/plot_dec_grph.R
@@ -1,9 +1,9 @@
 plot_dec_grph <- function(nodes = NULL, edges = NULL,
                           site, decor, doss = getwd(),
                           nd.color = "orange", nd.size = 1.7,
-                          lbl.color = "black", lbl.size = 1.2, lbl.txt = "id",
+                          lbl.color = "black", lbl.size = 1.2, nds.lbl = "id",
                           eds.color = c("orange","blue"), ed.lwd = 4) {
-    ## plot nodes on image lbl.txt = 'id' ; nd.color <- lbl.color <-
+    ## plot nodes on image nds.lbl = 'id' ; nd.color <- lbl.color <-
     ## ed.color <- 'orange' lbl.size=1.2 ; nd.size=1.7 ; ed.lwd <- 4 site <-
     ## 'Cerro Muriano' ; decor <- site <- 'Ibahernando' ;
     # images
@@ -34,14 +34,14 @@ plot_dec_grph <- function(nodes = NULL, edges = NULL,
                                 nodes$decor == decor, ]
         ax <- nodes.select$x
         ay <- -nodes.select$y  # coordinates
-        lbl <- nodes.select[, lbl.txt]  # labels
+        lbl <- nodes.select[, nds.lbl]  # labels
         graphics::points(ax, ay, pch = 21, col = nd.color, bg = nd.color,
             cex = nd.size)
         labels_shadow(ax, ay, label = lbl, col = lbl.color, bg = "white",
             cex = lbl.size, r = 0.2, pos = 3)
     }
     ## annotate studied variable up
-    img.out <- magick::image_annotate(img.out, lbl.txt, size = 20,
+    img.out <- magick::image_annotate(img.out, nds.lbl, size = 20,
                                       gravity = "northwest", color = "black")
     # decor title down
     tit.img <- paste0(site, "\n", decor)

--- a/R/same_elements.R
+++ b/R/same_elements.R
@@ -1,6 +1,6 @@
-same_elements <- function (lgrph, var = "type", focus = c("nodes")) {
-  extract_elements <- list(nodes = function(x) named_nodes(x, var),
-                           edges = function(x) named_edges(x, var))
+same_elements <- function (lgrph, nds.var = "type", focus = c("nodes")) {
+  extract_elements <- list(nodes = function(x) named_nodes(x, nds.var),
+                           edges = function(x) named_edges(x, nds.var))
   if (!focus %in% names(extract_elements)) {
     stop(paste0("focus must be \"nodes\" or \"edges\"."))
   }

--- a/R/side_plot.R
+++ b/R/side_plot.R
@@ -1,7 +1,7 @@
-side_plot <- function(grp, doss, var, focus = "nodes",
+side_plot <- function(grp, doss, nds.var, focus = "nodes",
                           nds.color = c("orange", "red"), nds.size = c(0.5, 1),
                           eds.color = c("orange", "red"), eds.width = c(1, 2),
-                          lbl.size = 0.4) {
+                          lbl.size = 0.5) {
   dec.img <- magick::image_read(paste0(doss, "/", grp$img))
   # add the decor site and name
   dec.img <- magick::image_annotate(dec.img,
@@ -43,6 +43,6 @@ side_plot <- function(grp, doss, var, focus = "nodes",
                    col = nds.color[nodes.group])
   # Get common nodes to plot labels
   nds.lbl <- g.nodes[nodes.group == 2, ]
-  labels_shadow(nds.lbl$x, nds.lbl$y, label = nds.lbl[, var],
+  labels_shadow(nds.lbl$x, nds.lbl$y, label = nds.lbl[, nds.var],
                 col = nds.color[2], bg = "white", cex = lbl.size, r = 0.15)
 }


### PR DESCRIPTION
Changed parameter var to nds.var, which always refers to nodes. The edge types are always at "type".

Inclusion of directed nature of edges of type ">" or "+". Now an edge A-->--B is not equal to B-->--A, and A--+--B is not equal to B--+--A. 
In contrast, A--=--B is equal to B--=--A.