### PR TITLE
Patch 47

### DIFF
--- a/R/label_shadow.R
+++ b/R/label_shadow.R
@@ -7,6 +7,7 @@ labels_shadow <- function(x,
                           r = 0.1, cex = 1, ...) {
     # all credits of the function go to Greg Snow see
     # https://rdrr.io/cran/TeachingDemos/man/shadowtext.html
+    if(length(labels) == 0) return()
     xy <- grDevices::xy.coords(x, y)
     xo <- r * cex * graphics::strwidth("A")
     yo <- r * cex * graphics::strheight("A")
@@ -14,7 +15,7 @@ labels_shadow <- function(x,
     # background
     for (i in theta) {
         graphics::text(xy$x + cos(i) * xo, xy$y + sin(i) * yo, labels,
-            col = "white", cex = cex, ...)
+            col = bg, cex = cex, ...)
     }
     # foreground
     graphics::text(xy$x, xy$y, labels, col = col, cex = cex, ...)

--- a/R/list_compar.R
+++ b/R/list_compar.R
@@ -14,7 +14,9 @@ list_compar <- function(lgrph, nds.var = "type",
       print(paste0("    ", dec, ") ", tit))
     }
     grph <- decorr::eds_compar(lgrph[idx.g], nds.var)
-    grphAllcompar[[dec]] <- decorr::nds_compar(grph, nds.var)
+    grph <- decorr::nds_compar(grph, nds.var)
+    grph$nds.var <- nds.var
+    grphAllcompar[[dec]] <- grph
   }
   return(grphAllcompar)
 }

--- a/R/plot_compar.R
+++ b/R/plot_compar.R
@@ -1,5 +1,5 @@
 plot_compar <- function(listg, graph2 = NULL, focus = "nodes",
-                        doss = getwd(), nds.var = "type",
+                        doss = getwd(),
                         nds.color = c("orange", "red"), nds.size = c(0.5, 1),
                         eds.color = c("orange", "red"), eds.width = c(1, 2),
                         lbl.size = 0.5,
@@ -12,14 +12,10 @@ plot_compar <- function(listg, graph2 = NULL, focus = "nodes",
 # Focus-specific parameter defaults and names:
   if (focus == "nodes") {
     img.prefix <- "compar_nds_"
-    caption.heading <- "nodes: "
-    caption.end <- ""
   } else if (focus == "edges") {
     if (missing(nds.color)) nds.color <- eds.color
     if (missing(nds.size)) nds.size[2] <- nds.size[1]
     img.prefix <- "compar_eds_"
-    caption.heading <- "edges: "
-    caption.end <- paste0(" on '", nds.var, "'")
   } else {
     stop(paste0("focus must be \"nodes\" or \"edges\"."))
   }
@@ -28,12 +24,17 @@ plot_compar <- function(listg, graph2 = NULL, focus = "nodes",
   for(i in 1:length(listg)) {
     # i <- 1
     g <- listg[[i]]
-    g.names <- unlist(lapply(g, function(x) x$name))
+    g.names <- unlist(lapply(g[1:2], function(x) x$name))
     if(is.null(graph2) || all(g.names %in% graph2)) {
+      nds.var <- g$nds.var
       out.compar <- paste0(img.prefix, g.names[1], "_",
                            g.names[2], ".", img.format)
-      tit <- paste0(caption.heading, "compare decorations '", g.names[1],
-                    "' and '", g.names[2], "'", caption.end)
+      com.elm.num <- ifelse(focus == "nodes", sum(igraph::V(g[[1]])$comm),
+                                              sum(igraph::E(g[[1]])$comm))
+      tit <- paste0("Common ", focus,
+                    " (n=", com.elm.num, "): ",
+                    "compare decorations '", g.names[1], "' and '", g.names[2],
+                    "' on nodes '", nds.var, "'")
       decorr::grDeviceOpen(out.compar, width = 14, height = 7, res = res)
       # Set the plotting area into a 1*2 array
       graphics::par(mfrow = c(1, 2), mar = c(0, 0, 0, 0))

--- a/R/side_plot.R
+++ b/R/side_plot.R
@@ -1,7 +1,7 @@
 side_plot <- function(grp, doss, nds.var, focus = "nodes",
-                          nds.color = c("orange", "red"), nds.size = c(0.5, 1),
-                          eds.color = c("orange", "red"), eds.width = c(1, 2),
-                          lbl.size = 0.5) {
+                      nds.color = c("orange", "red"), nds.size = c(0.5, 1),
+                      eds.color = c("orange", "red"), eds.width = c(1, 2),
+                      lbl.size = 0.5) {
   dec.img <- magick::image_read(paste0(doss, "/", grp$img))
   # add the decor site and name
   dec.img <- magick::image_annotate(dec.img,


### PR DESCRIPTION
Added the number of nodes/edges coincidences in the figure caption of plot_compar.

Removed the plot_compar parameter nds.var.
nds.var is now attached in the output of list_compar for each pairwise comparison. This allows the output to keep information about which nodes "type" has been used for the comparison. Thus, the plot_compar function does not need to be provided nds.var as an independent parameter, making the full pipeline more robust.

Bug correction is in label_shadow. Added handling of the exceptional case with zero-length labels. This was a bug since (in contrast with plot) the function graphics::text gives an error for zero-length labels.