### PR TITLE
Correct named_elements.R

### DIFF
--- a/R/named_elements.R
+++ b/R/named_elements.R
@@ -1,21 +1,17 @@
 #' @export
 named_elements <- function(grph, focus = "edges", nd.var = "type") {
   if(focus == "edges"){
-    # grph <- lgrph[[1]] ; nd.var = "type" ; directed.types = c(">", "+")
+    directed.types <- c(">", "+")
+    infix <- "-"
     grph.eds <- igraph::as_data_frame(grph)[, c("from", "type", "to")]
     grph.nds <- igraph::as_data_frame(grph, "vertices")
     grph.eds[c("from", "to")] <-
       grph.nds[unlist(grph.eds[c("from", "to")]), nd.var]
-    # if (!igraph::is_directed(grph)) {
-    # directed.eds = grph.eds$type %in% directed.types
-    # grph.eds[!grph.eds, c("from","to")] <-
-    #   t(apply(grph.eds[!grph.eds, c("from","to")], 1, sort))
-    # infix <- "--"
-    infix <- "-"
-    # } else {
-    #   # infix <- "->"
-    #   infix <- "-"
-    # }
+    if (!igraph::is_directed(grph)) {
+      directed.eds = grph.eds$type %in% directed.types
+      grph.eds[!directed.eds, c("from","to")] <-
+        t(apply(grph.eds[!directed.eds, c("from","to")], 1, sort))
+    }
     edges <- apply(grph.eds, 1, paste0, collapse = infix)
     return(disambiguate_duplicates(edges))
   }


### PR DESCRIPTION
Correct bug introduced when joined edges and nodes. In the uncorrected version, the edges with switched nodes where considered different for all types (included "="). Now it is correctly handled: Edges of type "=" are undirected and edges of type ">" and "+" are directed.